### PR TITLE
kk: Allow terminated statements without semicolons

### DIFF
--- a/public/app/.jshintrc
+++ b/public/app/.jshintrc
@@ -10,6 +10,7 @@
   "strict": true,
   "undef": true,
   "unused": true,
+  "asi": true,
   "globals": {
     "angular": false
   }


### PR DESCRIPTION
Not 100% sure, but I thought we wanted to allow statements without semicolons. Without this setting jshint is always complaining about missing semicolons.